### PR TITLE
Add FingerprintToUInt64 method for callers that prefer to handle uint64s

### DIFF
--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"testing"
 
 	pg_query "github.com/pganalyze/pg_query_go/v2"
@@ -38,6 +39,17 @@ func TestFingerprint(t *testing.T) {
 
 		if string(fingerprint) != test.ExpectedHash {
 			t.Errorf("Fingerprint(%s)\nexpected %s\nactual %s\n\n", test.Input, test.ExpectedHash, fingerprint)
+		}
+
+		fingerprintInt, err := pg_query.FingerprintToUInt64(test.Input)
+		if err != nil {
+			t.Errorf("FingerprintToUInt64(%s)\nparse error %s\n\n", test.Input, err)
+		}
+
+		expectedInt, _ := strconv.ParseUint(test.ExpectedHash, 16, 64)
+
+		if fingerprintInt != expectedInt {
+			t.Errorf("FingerprintToUInt64(%s)\nexpected %d\nactual %d\n\n", test.Input, expectedInt, fingerprintInt)
 		}
 	}
 

--- a/pg_query.go
+++ b/pg_query.go
@@ -44,7 +44,12 @@ func Normalize(input string) (result string, err error) {
 	return parser.Normalize(input)
 }
 
-// FastFingerprint - Fingerprint the passed SQL statement
+// Fingerprint - Fingerprint the passed SQL statement to a hex string
 func Fingerprint(input string) (result string, err error) {
-	return parser.Fingerprint(input)
+	return parser.FingerprintToHexStr(input)
+}
+
+// FingerprintToUInt64 - Fingerprint the passed SQL statement to a uint64
+func FingerprintToUInt64(input string) (result uint64, err error) {
+	return parser.FingerprintToUInt64(input)
 }


### PR DESCRIPTION
This prevents a caller from having to do a hex string to uint64 conversion
by simply returning the uint64 version of the fingerprint instead, which
is already always provided by libpg_query.