### PR TITLE
Add HashXXH3_64 helper method for generating XXH3 64-bit hash values

### DIFF
--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -55,3 +55,35 @@ func TestFingerprint(t *testing.T) {
 
 	fmt.Printf("\n")
 }
+
+var hashTests = []struct {
+	input    string
+	seed     uint64
+	expected uint64
+}{
+	{
+		"TEST",
+		0,
+		11717748491247689214,
+	},
+	{
+		"TEST",
+		42,
+		10412276358662179996,
+	},
+	{
+		"Something else",
+		0,
+		14679351602596009561,
+	},
+}
+
+func TestHashXXH3_64(t *testing.T) {
+	for _, test := range hashTests {
+		actual := pg_query.HashXXH3_64([]byte(test.input), test.seed)
+
+		if actual != test.expected {
+			t.Errorf("HashXXH3_64(%s)\nexpected %d\nactual %d\n\n", test.input, test.expected, actual)
+		}
+	}
+}

--- a/pg_query.go
+++ b/pg_query.go
@@ -53,3 +53,8 @@ func Fingerprint(input string) (result string, err error) {
 func FingerprintToUInt64(input string) (result uint64, err error) {
 	return parser.FingerprintToUInt64(input)
 }
+
+// HashXXH3_64 - Helper method to run XXH3 hash function (64-bit variant) on the given bytes, with the specified seed
+func HashXXH3_64(input []byte, seed uint64) (result uint64) {
+	return parser.HashXXH3_64(input, seed)
+}


### PR DESCRIPTION
This can be useful when trying to fit other values into a data structure
sized for the fingerprint, such as when encountering a parsing error
during fingerprinting, and wanting to encode that fact uniquely into
the fingerprint value.