### PR TITLE
Parser CFLAGS: Build with -std=gnu99 to ensure CentOS compatibility

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,7 @@
 package parser
 
 /*
-#cgo CFLAGS: -Iinclude -g -fstack-protector
+#cgo CFLAGS: -Iinclude -g -fstack-protector -std=gnu99
 #cgo LDFLAGS:
 #include "pg_query.h"
 #include "xxhash.h"


### PR DESCRIPTION
Go+GCC on CentOS requires explicitly setting the version of C99 that we want to build with.

"gnu99" seems like it comes closest to what Postgres itself builds with.