### PR TITLE
feat: publish a Go function corresponding to pg_query_scan

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -673,3 +673,18 @@ func TestParsePlPgSQL(t *testing.T) {
 		}
 	}
 }
+
+func TestScan(t *testing.T) {
+	smokeTest := func(input string) {
+		_, err := pg_query.Scan(input)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	for _, testCase := range parseTests {
+		smokeTest(testCase.input)
+	}
+	for _, testCase := range parsePlPgSQLTests {
+		smokeTest(testCase.input)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -51,6 +51,25 @@ func ParseToJSON(input string) (result string, err error) {
 	return
 }
 
+// Scans the given SQL statement into a protobuf ScanResult
+func ScanToProtobuf(input string) (result []byte, err error) {
+	inputC := C.CString(input)
+	defer C.free(unsafe.Pointer(inputC))
+
+	resultC := C.pg_query_scan(inputC)
+	defer C.pg_query_free_scan_result(resultC)
+
+	if resultC.error != nil {
+		errMessage := C.GoString(resultC.error.message)
+		err = errors.New(errMessage)
+		return
+	}
+
+	result = []byte(C.GoStringN(resultC.pbuf.data, C.int(resultC.pbuf.len)))
+
+	return
+}
+
 // ParseToProtobuf - Parses the given SQL statement into a parse tree (Protobuf format)
 func ParseToProtobuf(input string) (result []byte, err error) {
 	inputC := C.CString(input)

--- a/pg_query.go
+++ b/pg_query.go
@@ -6,6 +6,16 @@ import (
 	"github.com/pganalyze/pg_query_go/v2/parser"
 )
 
+func Scan(input string) (result *ScanResult, err error) {
+	protobufScan, err := parser.ScanToProtobuf(input)
+	if err != nil {
+		return
+	}
+	result = &ScanResult{}
+	err = proto.Unmarshal(protobufScan, result)
+	return
+}
+
 // ParseToJSON - Parses the given SQL statement into a parse tree (JSON format)
 func ParseToJSON(input string) (result string, err error) {
 	return parser.ParseToJSON(input)


### PR DESCRIPTION
Publishing `Scan(input string) (*ScanResult, error)` would let users access `*ScanResult`s. 

I only added smoke tests for this function since I figured the core functionality (tokenization) was covered by the test suite in libpg_query.

Would close #42.
