### PR TITLE
WIP: work on implementing SplitWithScanner

### DIFF
--- a/pg_query.go
+++ b/pg_query.go
@@ -33,6 +33,10 @@ func Parse(input string) (tree *ParseResult, err error) {
 	return
 }
 
+func SplitWithScanner(input string) (statements []string, err error) {
+	return parser.SplitWithScanner(input)
+}
+
 // Deparses a given Go parse tree into a SQL statement
 func Deparse(tree *ParseResult) (output string, err error) {
 	protobufTree, err := proto.Marshal(tree)

--- a/split_test.go
+++ b/split_test.go
@@ -1,0 +1,22 @@
+package pg_query_test
+
+import (
+	"testing"
+
+	_ "github.com/pganalyze/pg_query_go/v2"
+	pg_query "github.com/pganalyze/pg_query_go/v2"
+)
+
+func Test(t *testing.T) {
+	result, err := pg_query.SplitWithScanner("select 1; select 2; select 3;")
+	if err != nil {
+		t.Error(err)
+	} else {
+		expected := []string{"select 1", "select 2", "select 3"}
+		for i, res := range result {
+			if expected[i] != res {
+				t.Errorf("Unexpected split: %v", result)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Posting my progress. I'm having trouble dereferencing `PgQuerySplitStmt **stmts;` from `PgQuerySplitResult` as commented below.  Once this branch contains a working `SplitWithScanner(_)` and `SplitWithParser(_)` , I intend to squash my WIP commit to prevent debugging code from entering the codebase.
Relates to #51.
