### PR TITLE
Add native spinlock support on RISC-V

### DIFF
--- a/parser/include/storage/s_lock.h
+++ b/parser/include/storage/s_lock.h
@@ -315,12 +315,12 @@ tas(volatile slock_t *lock)
 #endif	 /* __ia64__ || __ia64 */
 
 /*
- * On ARM and ARM64, we use __sync_lock_test_and_set(int *, int) if available.
+ * On ARM, ARM64 and RISC-V, we use __sync_lock_test_and_set(int *, int) if available.
  *
  * We use the int-width variant of the builtin because it works on more chips
  * than other widths.
  */
-#if defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(__aarch64)
+#if defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(__aarch64) || defined(__riscv)
 #ifdef HAVE_GCC__SYNC_INT32_TAS
 #define HAS_TEST_AND_SET
 
@@ -337,7 +337,7 @@ tas(volatile slock_t *lock)
 #define S_UNLOCK(lock) __sync_lock_release(lock)
 
 #endif	 /* HAVE_GCC__SYNC_INT32_TAS */
-#endif	 /* __arm__ || __arm || __aarch64__ || __aarch64 */
+#endif	 /* __arm__ || __arm || __aarch64__ || __aarch64 || __riscv */
 
 
 /* S/390 and S/390x Linux (32- and 64-bit zSeries) */


### PR DESCRIPTION
Patch from https://www.postgresql.org/message-id/dea97b6d-f55f-1f6d-9109-504aa7dfa421@gentoo.org


> Hello,
> 
> 
> The attached patch adds native spinlock support to PostgreSQL on RISC-V 
> systems. As suspected by Richard W.M. Jones of Red Hat back in 2016, the 
> __sync_lock_test_and_set() approach applied on arm and arm64 works here 
> as well.
> 
> 
> Tested against PostgreSQL 13.3 on a physical rv64gc system (BeagleV 
> Starlight beta board) - builds and installs fine, all tests pass. From 
> what I can see in gcc documentation this should in theory work on rv32 
> (and possibly rv128) as well, therefore the patch as it stands covers 
> all RISC-V systems (i.e. doesn't check the value of __risc_xlen) - but I 
> haven't confirmed this experimentally.

