### PR TITLE
pg_config.h: NetBSD support

### DIFF
--- a/parser/include/pg_config.h
+++ b/parser/include/pg_config.h
@@ -990,6 +990,6 @@
 #undef HAVE_EXECINFO_H
 #undef HAVE_BACKTRACE_SYMBOLS
 #undef HAVE__GET_CPUID
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #define HAVE_STRCHRNUL
 #endif


### PR DESCRIPTION
NetBSD has `strchrnul` too but with a slightly different prototype. Without this change, there is a compiler error for a conflicting declaration.