### PR TITLE
Cgo: Add -Wno-unknown-warning-option to avoid warnings for Clang < 15

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,14 @@
 package parser
 
 /*
-#cgo CFLAGS: -Iinclude -g -fstack-protector -std=gnu99 -Wno-deprecated-non-prototype
+ * Note on CFLAGS below:
+ *
+ * -Wno-deprecated-non-prototype avoids warnings on Clang 15.0+, this can be removed in Postgres 16:
+ * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1c27d16e6e5c1f463bbe1e9ece88dda811235165
+ */
+
+/*
+#cgo CFLAGS: -Iinclude -g -fstack-protector -std=gnu99 -Wno-deprecated-non-prototype -Wno-unknown-warning-option
 #cgo LDFLAGS:
 #include "pg_query.h"
 #include "xxhash.h"


### PR DESCRIPTION
In passing, add an explanatory note on why the warnings are being ignored, and that we can remove this once upgrading the parser to PG 16.