### PR TITLE
End concurrency test with newline

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -658,6 +658,7 @@ func TestParseConcurrency(t *testing.T) {
 	}
 
 	wg.Wait()
+	fmt.Println()
 }
 
 var parsePlPgSQLTests = []struct {


### PR DESCRIPTION
Currently when running the test in GoLand, it fails to parse the test result because it isn't expecting the test runner's output to get mangled. I guess in general it's good to make sure the test's output doesn't collide with other output