### PR TITLE
Guard pg_query.go with not windows as well

### DIFF
--- a/pg_query.go
+++ b/pg_query.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !windows
+// +build cgo,!windows
 
 package pg_query
 


### PR DESCRIPTION
This is a followup to #102, in https://github.com/sqlc-dev/sqlc/pull/3027 we are trying to allow sqlc to run on windows using the wasm pgquery, even when cgo is enabled (this would allow windows to support both postgresql engine and wasmtime plugins). So it turned out we need to guard the cgo build from this repository against windows as well since it otherwise tries to compile and fail as we found in https://github.com/sqlc-dev/sqlc/pull/3035/files

I didn't add to the test files like before since it didn't seem necessary but let me know

/cc @kyleconroy