### PR TITLE
CHANGELOG and README fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 * Update to libpg_query 16-5.1.0
   - Add support for running on Windows
   - Add support for compiling on 32-bit systems
-* Treewalker: Allow passing a block with a single argument to walk!
-* PgQuery::Node: Add inner and inner= helpers to get/set inner object
 
 
 ## 5.0.0     2023-12-23

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main() {
 Running will output the query's parse tree as JSON:
 
 ```json
-{"version":150001,"stmts":[{"stmt":{"SelectStmt":{"targetList":[{"ResTarget":{"val":{"A_Const":{"ival":{"ival":1},"location":7}},"location":7}}],"limitOption":"LIMIT_OPTION_DEFAULT","op":"SETOP_NONE"}}}]}
+{"version":160001,"stmts":[{"stmt":{"SelectStmt":{"targetList":[{"ResTarget":{"val":{"A_Const":{"ival":{"ival":1},"location":7}},"location":7}}],"limitOption":"LIMIT_OPTION_DEFAULT","op":"SETOP_NONE"}}}]}
 ```
 
 ### Parsing a query into Go structs


### PR DESCRIPTION
```
CHANGELOG: Remove incorrect entries from 5.1.0 changelog 

These were accidentally copied over from the Ruby library, and don't
apply to Go.
```

```
README: Update parse output to match Postgres 16
```