### PR TITLE
Ensure update_source always works from a clean state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(LIBDIRGZ):
 	mkdir -p $(LIB_TMPDIR)
 	curl -o $(LIBDIRGZ) https://codeload.github.com/pganalyze/libpg_query/tar.gz/$(LIB_PG_QUERY_TAG)
 
-update_source: $(LIBDIR)
+update_source: clean $(LIBDIR)
 	rm -f parser/*.{c,h}
 	rm -fr parser/include
 	# Reduce everything down to one directory


### PR DESCRIPTION
If `make clean` isn't called before `make update_source`, changes to `LIB_PG_QUERY_TAG` won't take effect because of the locally cached state. Fix that by ensuring `clean` is a dependency for `update_source` so it's always called first.