### PR TITLE
Add IsUtilityStmt to return whether statements are utility statements

### DIFF
--- a/is_utility_test.go
+++ b/is_utility_test.go
@@ -1,0 +1,117 @@
+//go:build cgo
+// +build cgo
+
+package pg_query_test
+
+import (
+	"reflect"
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/pganalyze/pg_query_go/v6/parser"
+)
+
+var isUtilityStmtTests = []struct {
+	input    string
+	expected []bool
+}{
+	// DML statements (not utility)
+	{
+		"SELECT 1",
+		[]bool{false},
+	},
+	{
+		"INSERT INTO t (a) VALUES (1)",
+		[]bool{false},
+	},
+	{
+		"UPDATE t SET a = 1",
+		[]bool{false},
+	},
+	{
+		"DELETE FROM t",
+		[]bool{false},
+	},
+	// Utility statements
+	{
+		"SHOW fsync",
+		[]bool{true},
+	},
+	{
+		"SET fsync = off",
+		[]bool{true},
+	},
+	{
+		"CREATE TABLE t (a int)",
+		[]bool{true},
+	},
+	{
+		"DROP TABLE t",
+		[]bool{true},
+	},
+	// Multi-statement input
+	{
+		"SELECT 1; SELECT 2",
+		[]bool{false, false},
+	},
+	{
+		"SELECT 1; SHOW fsync",
+		[]bool{false, true},
+	},
+	{
+		"SHOW fsync; SELECT 1",
+		[]bool{true, false},
+	},
+	{
+		"SET a = 1; SET b = 2",
+		[]bool{true, true},
+	},
+}
+
+func TestIsUtilityStmt(t *testing.T) {
+	for _, test := range isUtilityStmtTests {
+		actual, err := pg_query.IsUtilityStmt(test.input)
+
+		if err != nil {
+			t.Errorf("IsUtilityStmt(%s)\nerror %s\n\n", test.input, err)
+		} else if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("IsUtilityStmt(%s)\nexpected %v\nactual %v\n\n", test.input, test.expected, actual)
+		}
+	}
+}
+
+var isUtilityStmtErrorTests = []struct {
+	input       string
+	expectedErr error
+}{
+	{
+		"SELECT $",
+		&parser.Error{
+			Message:   "syntax error at or near \"$\"",
+			Cursorpos: 8,
+			Filename:  "scan.l",
+			Funcname:  "scanner_yyerror",
+		},
+	},
+}
+
+func TestIsUtilityStmtError(t *testing.T) {
+	for _, test := range isUtilityStmtErrorTests {
+		_, actualErr := pg_query.IsUtilityStmt(test.input)
+
+		if actualErr == nil {
+			t.Errorf("IsUtilityStmt(%s)\nexpected error but none returned\n\n", test.input)
+		} else {
+			exp := test.expectedErr.(*parser.Error)
+			act := actualErr.(*parser.Error)
+			act.Lineno = 0 // Line number is architecture dependent, so we ignore it
+			if !reflect.DeepEqual(act, exp) {
+				t.Errorf(
+					"IsUtilityStmt(%s)\nexpected error %s at %d (%s:%d), func: %s, context: %s\nactual error %+v at %d (%s:%d), func: %s, context: %s\n\n",
+					test.input,
+					exp.Message, exp.Cursorpos, exp.Filename, exp.Lineno, exp.Funcname, exp.Context,
+					act.Message, act.Cursorpos, act.Filename, act.Lineno, act.Funcname, act.Context)
+			}
+		}
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -288,3 +288,24 @@ func HashXXH3_64(input []byte, seed uint64) (result uint64) {
 
 	return
 }
+
+// IsUtilityStmt - Determines whether each statement in the query is a utility statement
+func IsUtilityStmt(input string) (result []bool, err error) {
+	inputC := C.CString(input)
+	defer C.free(unsafe.Pointer(inputC))
+
+	resultC := C.pg_query_is_utility_stmt(inputC)
+	defer C.pg_query_free_is_utility_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = make([]bool, resultC.length)
+	for i, item := range unsafe.Slice(resultC.items, resultC.length) {
+		result[i] = bool(item)
+	}
+
+	return
+}

--- a/pg_query.go
+++ b/pg_query.go
@@ -84,3 +84,11 @@ func SplitWithScanner(input string, trimSpace bool) (result []string, err error)
 func SplitWithParser(input string, trimSpace bool) (result []string, err error) {
 	return parser.SplitWithParser(input, trimSpace)
 }
+
+// IsUtilityStmt - Determines whether each statement in the query is a utility statement
+//
+// Returns a slice of booleans, one for each statement in the query.
+// true = utility statement / DDL, false = SELECT / INSERT / UPDATE / DELETE / MERGE
+func IsUtilityStmt(input string) (result []bool, err error) {
+	return parser.IsUtilityStmt(input)
+}


### PR DESCRIPTION
This avoids having to deal with Protobuf serialization/deserialization when the caller is only interested to know if the input statements are utility statements. As a side effect, this method also allows inferring the number of statements (separated by ";") in the input.

**Note on AI use:** I used Claude Code for the initial version, but edited the implementation to simplify it, and adjusted comments.